### PR TITLE
Fix types in structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ async-std = { version = "1.6.0", features = ["attributes"] }
 itertools = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4.8"
+time = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
 structopt = "0.3"


### PR DESCRIPTION
Just earlier today, I thought about creating a rust library for mpd, just like this one. Looks like I wasn’t the only person who felt like doing that.

Most of these fields should be unsigned integers.
I’ve also replaced the numbers that represent durations with
time::Duration because that (or any other time/duration type) is what a consumer of the library would expect to get.
The time crate was choosen because it provides serde derives and
implements Default for its types which minimizes the necessary changes
to existing code.

The (De)Serialize trait isn’t actually used yet, but I think serde_derive is the way to go when adding more structs, so I definitely wanted a type that can be deserialized.

Example of using the new duration fields:
```rust
let mut client = MpdClient::new("[::]:6600").await?;
let pt = client.stats().await?.playtime;
println!(
    "{} days, {}:{}:{}",
    pt.whole_days(),
    pt.whole_hours() % 24,
    pt.whole_minutes() % 60,
    pt.whole_seconds() % 60
);
```
which would print something like `134 days, 11:51:24`.