### PR TITLE
Deserialize responses with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 async-std = { version = "1.6.0", features = ["attributes"] }
 itertools = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
+# The MPD responses are (almost) a tiny subset of yaml.
+# It might make sense to write a custom parser at some point instead.
+serde_yaml = "0.8"
 log = "0.4.8"
 time = { version = "0.2", features = ["serde"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub struct Stats {
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
 /// Subsystem
 pub enum Subsystem {
     Database,
@@ -128,6 +129,7 @@ pub enum Subsystem {
     Mixer,
     Options,
     Update,
+    #[serde(rename = "stored_playlist")]
     StoredPlaylist,
     Playlist,
     Output,
@@ -261,24 +263,7 @@ impl MpdClient {
                 return Ok(None);
             }
 
-            return Ok(match v {
-                "database" => Some(Subsystem::Database),
-                "player" => Some(Subsystem::Player),
-                "mixer" => Some(Subsystem::Mixer),
-                "options" => Some(Subsystem::Options),
-                "update" => Some(Subsystem::Update),
-                "stored_playlist" => Some(Subsystem::StoredPlaylist),
-                "playlist" => Some(Subsystem::Playlist),
-                "output" => Some(Subsystem::Output),
-                "partitions" => Some(Subsystem::Partitions),
-                "sticker" => Some(Subsystem::Sticker),
-                "subscription" => Some(Subsystem::Subscription),
-                "message" => Some(Subsystem::Message),
-                _ => {
-                    log::debug!("unknown subsystem {}", v);
-                    None
-                }
-            });
+            return Ok(serde_yaml::from_str(v).ok());
         }
         Ok(None)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,12 @@ use async_std::{
 use itertools::Itertools;
 use log::{info, trace, warn};
 use serde::de::{self, Unexpected};
-use serde::{Deserialize, Deserializer};
-use std::fmt::{self, Debug};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt::Debug;
 use std::io;
 use time::Duration;
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 /// Mpd status response
 pub struct Status {
     /// Name of current partition
@@ -89,7 +89,7 @@ pub struct Status {
     pub error: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 /// Track in Queue
 pub struct QueuedTrack {
     pub file: String,
@@ -105,7 +105,7 @@ pub struct QueuedTrack {
     pub id: u32,
 }
 
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 /// Mpd database statistics
 pub struct Stats {
     #[serde(deserialize_with = "de_time_int")]
@@ -120,7 +120,7 @@ pub struct Stats {
     pub db_update: i32,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "lowercase")]
 /// Subsystem
 pub enum Subsystem {


### PR DESCRIPTION
Since serde_derive was a dependency already, I figured we could use it to read the responses.
This will save a lot of work when adding more structs.
I provided deserializers for `(0|1) -> bool` and parsing times from int and float because those were needed for `Stats` and `Status`.

This is using yaml deserialization for now because the mpd responses are almost always valid yaml, but there might be problems if values contain a colon.
That’s something I want to address later, either by writing a parser for this format (I don’t know how much work that would be) or by preprocessing the responses somehow (i.e. stripping colons from values).

I couldn’t figure out how to use serde_from_reader to read the serialized data directly from the stream without first allocating the string vector, but there’s definitely room for improvement there.

I tested the deserialization for running and stopped mpd.
I hope I found and marked all optional fields, but I sadly can’t promise that.
Only time will tell.