### PR TITLE
Add async_mpd::Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_yaml = "0.8"
 serde_with = "1.4.0"
 log = "0.4.8"
 chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1.0.20"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 #[async_std::main]
-async fn main() -> std::io::Result<()> {
+async fn main() -> Result<(), async_mpd::Error> {
     // Connect to server
     let mut mpd = async_mpd::MpdClient::new("localhost:6600").await?;
 

--- a/examples/mpc-lite.rs
+++ b/examples/mpc-lite.rs
@@ -1,4 +1,4 @@
-use async_mpd::{Filter, MpdClient, Tag, ToFilterExpr};
+use async_mpd::{Error, Filter, MpdClient, Tag, ToFilterExpr};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -51,7 +51,7 @@ enum Command {
 }
 
 #[async_std::main]
-async fn main() -> std::io::Result<()> {
+async fn main() -> Result<(), Error> {
     femme::with_level(log::LevelFilter::Trace);
 
     let opt = Opt::from_args();

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use async_std::{
     prelude::*,
 };
 use itertools::Itertools;
-use log::{info, warn};
+use log::{info};
 use std::io;
 
 use crate::{
@@ -12,6 +12,26 @@ use crate::{
     response::{self, Mixed},
     Stats, Status, Subsystem, Track,
 };
+
+/// Error
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Server failed to parse the command
+    #[error("Invalid command or arguments")]
+    CommandError { msg: String },
+
+    /// The server closed the connection
+    #[error("The server closed the connection")]
+    Disconnected,
+
+    /// Represents all other cases of `std::io::Error`.
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+
+    /// Failed to parse the reply the server sent
+    #[error("Invalid reply to command")]
+    ResponseError { reply: String, errmsg: String },
+}
 
 /// Mpd Client
 pub struct MpdClient {
@@ -21,7 +41,7 @@ pub struct MpdClient {
 
 impl MpdClient {
     /// Create a new MpdClient and connect to `addr`
-    pub async fn new<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub async fn new<A: ToSocketAddrs>(addr: A) -> Result<Self, Error> {
         let stream = TcpStream::connect(addr).await?;
 
         // Save if we need to reconnect later
@@ -37,28 +57,32 @@ impl MpdClient {
         Ok(s)
     }
 
-    async fn read_version(&mut self) -> io::Result<()> {
+    async fn read_version(&mut self) -> Result<(), Error> {
         self.version = self.read_resp_line().await?;
         info!("version: {}", self.version);
         Ok(())
     }
 
     /// Get stats on the music database
-    pub async fn stats(&mut self) -> io::Result<Stats> {
+    pub async fn stats(&mut self) -> Result<Stats, Error> {
         self.cmd("stats").await?;
         let lines = self.read_resp().await?;
-        Ok(serde_yaml::from_str(&lines)
-            .unwrap_or_else(|e| panic!("Failed to parse mpd response: “{}” with {}", &lines, e)))
+        serde_yaml::from_str(&lines).map_err(|err| Error::ResponseError {
+            reply: lines,
+            errmsg: err.to_string(),
+        })
     }
 
-    pub async fn status(&mut self) -> io::Result<Status> {
+    pub async fn status(&mut self) -> Result<Status, Error> {
         self.cmd("status").await?;
         let lines = self.read_resp().await?;
-        Ok(serde_yaml::from_str(&lines)
-            .unwrap_or_else(|e| panic!("Failed to parse mpd response: “{}” with {}", &lines, e)))
+        serde_yaml::from_str(&lines).map_err(|err| Error::ResponseError {
+            reply: lines,
+            errmsg: err.to_string(),
+        })
     }
 
-    pub async fn update(&mut self, path: Option<&str>) -> io::Result<i32> {
+    pub async fn update(&mut self, path: Option<&str>) -> Result<i32, Error> {
         self.cmd(Cmd::new("update", path)).await?;
         let r = self.read_resp_line().await?;
 
@@ -70,7 +94,7 @@ impl MpdClient {
         Ok(db_version)
     }
 
-    pub async fn rescan(&mut self, path: Option<&str>) -> io::Result<i32> {
+    pub async fn rescan(&mut self, path: Option<&str>) -> Result<i32, Error> {
         self.cmd(Cmd::new("rescan", path)).await?;
         let r = self.read_resp_line().await?;
 
@@ -82,7 +106,7 @@ impl MpdClient {
         Ok(db_version)
     }
 
-    pub async fn idle(&mut self) -> io::Result<Option<Subsystem>> {
+    pub async fn idle(&mut self) -> Result<Option<Subsystem>, Error> {
         self.cmd("idle").await?;
         let resp = self.read_resp().await?;
         let mut lines = resp.lines();
@@ -103,33 +127,33 @@ impl MpdClient {
         Ok(None)
     }
 
-    pub async fn noidle(&mut self) -> io::Result<()> {
+    pub async fn noidle(&mut self) -> Result<(), Error> {
         self.cmd("noidle").await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn setvol(&mut self, volume: u32) -> io::Result<()> {
+    pub async fn setvol(&mut self, volume: u32) -> Result<(), Error> {
         self.cmd(Cmd::new("setvol", Some(volume))).await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn repeat(&mut self, repeat: bool) -> io::Result<()> {
+    pub async fn repeat(&mut self, repeat: bool) -> Result<(), Error> {
         let repeat = if repeat { 1 } else { 0 };
         self.cmd(Cmd::new("repeat", Some(repeat))).await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn random(&mut self, random: bool) -> io::Result<()> {
+    pub async fn random(&mut self, random: bool) -> Result<(), Error> {
         let random = if random { 1 } else { 0 };
         self.cmd(Cmd::new("random", Some(random))).await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn consume(&mut self, consume: bool) -> io::Result<()> {
+    pub async fn consume(&mut self, consume: bool) -> Result<(), Error> {
         let consume = if consume { 1 } else { 0 };
         self.cmd(Cmd::new("consume", Some(consume))).await?;
         self.read_ok_resp().await?;
@@ -138,40 +162,40 @@ impl MpdClient {
 
     // Playback controls
 
-    pub async fn play(&mut self) -> io::Result<()> {
+    pub async fn play(&mut self) -> Result<(), Error> {
         self.play_pause(true).await
     }
 
-    pub async fn playid(&mut self, id: u32) -> io::Result<()> {
+    pub async fn playid(&mut self, id: u32) -> Result<(), Error> {
         self.cmd(Cmd::new("playid", Some(id))).await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn pause(&mut self) -> io::Result<()> {
+    pub async fn pause(&mut self) -> Result<(), Error> {
         self.play_pause(false).await
     }
 
-    pub async fn play_pause(&mut self, play: bool) -> io::Result<()> {
+    pub async fn play_pause(&mut self, play: bool) -> Result<(), Error> {
         let play = if play { 0 } else { 1 };
         self.cmd(Cmd::new("pause", Some(play))).await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn next(&mut self) -> io::Result<()> {
+    pub async fn next(&mut self) -> Result<(), Error> {
         self.cmd("next").await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn prev(&mut self) -> io::Result<()> {
+    pub async fn prev(&mut self) -> Result<(), Error> {
         self.cmd("prev").await?;
         self.read_ok_resp().await?;
         Ok(())
     }
 
-    pub async fn stop(&mut self) -> io::Result<()> {
+    pub async fn stop(&mut self) -> Result<(), Error> {
         self.cmd("stop").await?;
         self.read_ok_resp().await?;
         Ok(())
@@ -179,7 +203,7 @@ impl MpdClient {
 
     // Music database commands
 
-    pub async fn listall(&mut self, path: Option<String>) -> io::Result<Vec<String>> {
+    pub async fn listall(&mut self, path: Option<String>) -> Result<Vec<String>, Error> {
         self.cmd(Cmd::new("listall", path)).await?;
 
         Ok(self
@@ -196,7 +220,7 @@ impl MpdClient {
             .collect())
     }
 
-    pub async fn listallinfo(&mut self, path: Option<&str>) -> io::Result<Vec<Mixed>> {
+    pub async fn listallinfo(&mut self, path: Option<&str>) -> Result<Vec<Mixed>, Error> {
         self.cmd(Cmd::new("listallinfo", path)).await?;
 
         let resp = self.read_resp().await?;
@@ -206,17 +230,17 @@ impl MpdClient {
 
     // Queue handling commands
 
-    pub async fn queue_add(&mut self, path: &str) -> io::Result<()> {
+    pub async fn queue_add(&mut self, path: &str) -> Result<(), Error> {
         self.cmd(Cmd::new("add", Some(path))).await?;
         self.read_ok_resp().await
     }
 
-    pub async fn queue_clear(&mut self) -> io::Result<()> {
+    pub async fn queue_clear(&mut self) -> Result<(), Error> {
         self.cmd("clear").await?;
         self.read_ok_resp().await
     }
 
-    pub async fn queue(&mut self) -> io::Result<Vec<Track>> {
+    pub async fn queue(&mut self) -> Result<Vec<Track>, Error> {
         self.cmd("playlistinfo").await?;
         let resp = self.read_resp().await?;
         let vec = response::tracks(&resp);
@@ -225,10 +249,10 @@ impl MpdClient {
 
     /// # Example
     /// ```
-    /// use async_mpd::{MpdClient, Tag, Filter, ToFilterExpr};
+    /// use async_mpd::{MpdClient, Error, Tag, Filter, ToFilterExpr};
     ///
     /// #[async_std::main]
-    /// async fn main() -> std::io::Result<()> {
+    /// async fn main() -> Result<(), Error> {
     ///     // Connect to server
     ///     let mut mpd = MpdClient::new("localhost:6600").await?;
     ///
@@ -242,7 +266,7 @@ impl MpdClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn search(&mut self, filter: &Filter) -> io::Result<Vec<Track>> {
+    pub async fn search(&mut self, filter: &Filter) -> Result<Vec<Track>, Error> {
         self.cmd(Cmd::new("search", filter.to_query())).await?;
         let resp = self.read_resp().await?;
         let tracks = response::tracks(&resp);
@@ -256,14 +280,14 @@ impl MpdClient {
     }
 
     /// Read all response lines
-    async fn read_resp(&mut self) -> io::Result<String> {
+    async fn read_resp(&mut self) -> Result<String, Error> {
         let mut v = Vec::new();
 
         loop {
             let mut line = String::new();
 
             if self.bufreader.read_line(&mut line).await? == 0 {
-                break;
+                return Err(Error::Disconnected);
             }
 
             let line = line.trim();
@@ -274,7 +298,7 @@ impl MpdClient {
 
             if line.starts_with("ACK ") {
                 log::trace!("Cmd error: {}", line);
-                break;
+                return Err(Error::CommandError { msg: line.into() });
             }
 
             v.push(line.to_string())
@@ -284,19 +308,22 @@ impl MpdClient {
     }
 
     /// Expect one line response
-    async fn read_resp_line(&mut self) -> io::Result<String> {
+    async fn read_resp_line(&mut self) -> Result<String, Error> {
         let mut line = String::new();
         self.bufreader.read_line(&mut line).await?;
         Ok(line.trim().to_string())
     }
 
     /// Read and expect OK response line
-    async fn read_ok_resp(&mut self) -> io::Result<()> {
+    async fn read_ok_resp(&mut self) -> Result<(), Error> {
         let mut line = String::new();
         self.bufreader.read_line(&mut line).await?;
 
         if &line != "OK\n" {
-            warn!("Expected OK, got: {}", line);
+            return Err(Error::ResponseError {
+                reply: line.to_string(),
+                errmsg: "Expected OK".to_string()
+            })
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! use async_mpd::MpdClient;
 //!
 //! #[async_std::main]
-//! async fn main() -> std::io::Result<()> {
+//! async fn main() -> Result<(), async_mpd::Error> {
 //!     // Connect to server
 //!     let mut mpd = MpdClient::new("localhost:6600").await?;
 //!
@@ -39,7 +39,7 @@ use std::time::Duration;
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
-pub use client::MpdClient;
+pub use {client::Error, client::MpdClient};
 
 #[cfg(feature = "client")]
 mod response;

--- a/src/response.rs
+++ b/src/response.rs
@@ -31,7 +31,11 @@ impl Mixed {
 }
 
 pub(crate) fn tracks(resp: &str) -> Vec<Track> {
-    mixed(resp).iter().filter_map(Mixed::track).cloned().collect()
+    mixed(resp)
+        .iter()
+        .filter_map(Mixed::track)
+        .cloned()
+        .collect()
 }
 
 pub(crate) fn mixed(resp: &str) -> Vec<Mixed> {


### PR DESCRIPTION
I'm no expert on error handling in Rust but after reading https://nick.groenen.me/posts/rust-error-handling/ I decided to use thiserror for error handling in async-mpd.

There are room for improvements, the ACK response could probably be parsed to its own struct.

This should address #5, no more panicing in the library on disconnect or unrecognized responses 

Closes: #5 