### PR TITLE
fix: send "previous" instead of "prev" for Prev command

### DIFF
--- a/src/client/cmd.rs
+++ b/src/client/cmd.rs
@@ -172,7 +172,7 @@ impl MpdCmd for Next {
     type Handler = OkResponse;
 }
 impl MpdCmd for Prev {
-    const CMD: &'static str = "prev";
+    const CMD: &'static str = "previous";
     type Handler = OkResponse;
 }
 


### PR DESCRIPTION
## Bug

The MPD protocol command to go to the previous track is `previous`, not `prev`. Sending `prev` results in:

```
ACK [5@0] {} unknown command "prev"
```

This means `MpdClient::prev()` always returns an error — it has never worked against a real MPD server.

## Fix

Change `cmd::Prev::CMD` from `"prev"` to `"previous"`.

## Verification

Tested against MPD 0.23.5:
```
$ echo 'prev' | nc localhost 6600
ACK [5@0] {} unknown command "prev"

$ echo 'previous' | nc localhost 6600
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)