### PR TITLE
Add `queue_insert` method

### DIFF
--- a/src/client/cmd.rs
+++ b/src/client/cmd.rs
@@ -5,7 +5,7 @@ use crate::{
         handlers::{MixedResponseResponse, OkResponse, RespMapResponse, ResponseHandler, Tracks},
         respmap_handlers::ListallResponse,
     },
-    DatabaseVersion,
+    DatabaseVersion, Id,
 };
 
 #[derive(Copy, Clone)]
@@ -90,7 +90,7 @@ impl<'a> MpdCmd for ListallInfo<'a> {
 
 impl<'a> MpdCmd for QueueInsert<'a> {
     const CMD: &'static str = "addid";
-    type Handler = OkResponse;
+    type Handler = RespMapResponse<Id>;
 
     fn to_cmdline(&self) -> String {
         format!("{} \"{}\" \"{}\"\n", Self::CMD, self.0, self.1)

--- a/src/client/cmd.rs
+++ b/src/client/cmd.rs
@@ -28,6 +28,8 @@ pub struct PlayId(pub u32);
 pub struct QueueClear;
 #[derive(Copy, Clone)]
 pub struct QueueAdd<'a>(pub &'a str);
+#[derive(Copy, Clone)]
+pub struct QueueInsert<'a>(pub &'a str, pub u32);
 
 #[derive(Copy, Clone)]
 pub struct Search<'a>(pub Option<&'a str>);
@@ -83,6 +85,15 @@ impl<'a> MpdCmd for ListallInfo<'a> {
 
     fn argument(&self) -> Option<String> {
         self.0.map(ToString::to_string)
+    }
+}
+
+impl<'a> MpdCmd for QueueInsert<'a> {
+    const CMD: &'static str = "addid";
+    type Handler = OkResponse;
+
+    fn to_cmdline(&self) -> String {
+        format!("{} \"{}\" \"{}\"\n", Self::CMD, self.0, self.1)
     }
 }
 

--- a/src/client/mpdclient.rs
+++ b/src/client/mpdclient.rs
@@ -10,7 +10,7 @@ use crate::{
         respmap_handlers::{ListallResponse, ListallinfoResponse},
     },
     cmd::{self, MpdCmd},
-    DatabaseVersion, Error, Filter, Stats, Status, Subsystem, Track,
+    DatabaseVersion, Id, Error, Filter, Stats, Status, Subsystem, Track,
 };
 
 /// Mpd Client
@@ -155,7 +155,7 @@ impl MpdClient {
         self.exec(cmd::QueueAdd(path)).await
     }
 
-    pub async fn queue_insert(&mut self, path: &str, position: u32) -> Result<(), Error> {
+    pub async fn queue_insert(&mut self, path: &str, position: u32) -> Result<Id, Error> {
         self.exec(cmd::QueueInsert(path, position)).await
     }
 

--- a/src/client/mpdclient.rs
+++ b/src/client/mpdclient.rs
@@ -155,6 +155,10 @@ impl MpdClient {
         self.exec(cmd::QueueAdd(path)).await
     }
 
+    pub async fn queue_insert(&mut self, path: &str, position: u32) -> Result<(), Error> {
+        self.exec(cmd::QueueInsert(path, position)).await
+    }
+
     pub async fn queue_clear(&mut self) -> Result<(), Error> {
         self.exec(cmd::QueueClear).await
     }

--- a/src/client/resp/mod.rs
+++ b/src/client/resp/mod.rs
@@ -1,6 +1,6 @@
 use crate::client::resp::respmap_handlers::{ListallResponse, ListallinfoResponse};
 use crate::protocol::Stats;
-use crate::{protocol, DatabaseVersion, Error, Status, Subsystem, Track};
+use crate::{protocol, DatabaseVersion, Id, Error, Status, Subsystem, Track};
 use async_net::TcpStream;
 use futures_lite::io::BufReader;
 use futures_lite::AsyncBufReadExt;
@@ -24,6 +24,7 @@ pub enum WrappedResponse {
     Listall(ListallResponse),
     Subsystem(Subsystem),
     DatabaseVersion(DatabaseVersion),
+    Id(Id),
     Status(Status),
     Stats(Stats),
 }
@@ -61,6 +62,12 @@ impl From<protocol::Subsystem> for WrappedResponse {
 impl From<protocol::DatabaseVersion> for WrappedResponse {
     fn from(d: DatabaseVersion) -> Self {
         WrappedResponse::DatabaseVersion(d)
+    }
+}
+
+impl From<protocol::Id> for WrappedResponse {
+    fn from(d: Id) -> Self {
+        WrappedResponse::Id(d)
     }
 }
 

--- a/src/client/resp/respmap_handlers.rs
+++ b/src/client/resp/respmap_handlers.rs
@@ -5,7 +5,7 @@ use futures_lite::{io::AsyncBufReadExt, io::BufReader, StreamExt};
 use serde::Serialize;
 
 use crate::client::resp::respmap::RespMap;
-use crate::{DatabaseVersion, Directory, Playlist, State, Stats, Status, Subsystem, Track};
+use crate::{DatabaseVersion, Id, Directory, Playlist, State, Stats, Status, Subsystem, Track};
 use std::convert::TryFrom;
 
 impl From<RespMap> for Subsystem {
@@ -48,6 +48,13 @@ impl From<RespMap> for DatabaseVersion {
     fn from(mut map: RespMap) -> Self {
         let v = map.get_def("updating_db");
         DatabaseVersion(v)
+    }
+}
+
+impl From<RespMap> for Id {
+    fn from(mut map: RespMap) -> Self {
+        let v = map.get_def("Id");
+        Id(v)
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -87,6 +87,9 @@ pub struct Stats {
 pub struct DatabaseVersion(pub u32);
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct Id(pub u32);
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
 /// Track
 pub struct Track {
     pub file: String,


### PR DESCRIPTION
Allows inserting a track at a specific position in the queue (as opposed to `queue_add` which inserts at the end).